### PR TITLE
Change name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,16 +88,16 @@ jobs:
             sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 60
 
       - name: Test default features
-        run: cargo miri test --package capnp --package capnpc-test
+        run: cargo miri test --package capstone --package capnpc-test
 
       - name: Test no default features
-        run: cargo miri test --package capnp --package capnpc-test --no-default-features
+        run: cargo miri test --package capstone --package capnpc-test --no-default-features
 
       - name: Test sync_reader
-        run: cargo miri test --package capnp --package capnpc-test --features sync_reader
+        run: cargo miri test --package capstone --package capnpc-test --features sync_reader
 
       - name: Test unaligned
-        run: cargo miri test --package capnp --package capnpc-test --features unaligned
+        run: cargo miri test --package capstone --package capnpc-test --features unaligned
 
   minrust:
     name: minrust
@@ -131,7 +131,7 @@ jobs:
           cd ../
 
     - name: Run tests
-      run: cargo test -p capnp -p capnpc -p capnp-futures -p capnp-rpc
+      run: cargo test -p capstone -p capstone-gen -p capstone-futures -p capstone-rpc
 
   fmt:
     name: formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,16 +15,16 @@ dependencies = [
 name = "addressbook"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
+ "capstone",
+ "capstone-import",
 ]
 
 [[package]]
 name = "addressbook_send"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
+ "capstone",
+ "capstone-import",
 ]
 
 [[package]]
@@ -109,8 +109,8 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "benchmark"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
+ "capstone",
+ "capstone-import",
 ]
 
 [[package]]
@@ -197,16 +197,75 @@ dependencies = [
 name = "calculator"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
- "capnp-rpc",
+ "capstone",
+ "capstone-import",
+ "capstone-rpc",
  "futures",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
-name = "capnp"
+name = "capnp-futures-test"
+version = "0.0.0"
+dependencies = [
+ "async-byte-channel",
+ "capstone",
+ "capstone-futures",
+ "capstone-import",
+ "futures",
+]
+
+[[package]]
+name = "capnp-rpc-test"
+version = "0.0.0"
+dependencies = [
+ "async-byte-channel",
+ "capstone",
+ "capstone-import",
+ "capstone-rpc",
+ "futures",
+ "tokio",
+]
+
+[[package]]
+name = "capnpc-test"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "capstone",
+ "capstone-gen",
+ "capstone-import",
+ "external-crate",
+ "tempfile",
+]
+
+[[package]]
+name = "capnpc-test-edition-2018"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "capstone",
+ "capstone-gen",
+ "capstone-import",
+ "external-crate",
+ "tempfile",
+]
+
+[[package]]
+name = "capnpc-test-edition-2021"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "capstone",
+ "capstone-gen",
+ "capstone-import",
+ "external-crate",
+ "tempfile",
+]
+
+[[package]]
+name = "capstone"
 version = "0.18.0"
 dependencies = [
  "embedded-io",
@@ -215,32 +274,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "capnp-futures"
+name = "capstone-futures"
 version = "0.18.0"
 dependencies = [
- "capnp",
+ "capstone",
  "futures",
  "quickcheck",
 ]
 
 [[package]]
-name = "capnp-futures-test"
-version = "0.0.0"
+name = "capstone-gen"
+version = "0.18.0"
 dependencies = [
- "async-byte-channel",
- "capnp",
- "capnp-futures",
- "capnp-import",
- "futures",
+ "capstone",
 ]
 
 [[package]]
-name = "capnp-import"
+name = "capstone-import"
 version = "0.18.0"
 dependencies = [
  "anyhow",
- "capnp",
- "capnpc",
+ "capstone",
+ "capstone-gen",
  "cmake",
  "convert_case",
  "proc-macro2",
@@ -256,12 +311,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "capnp-macros"
+name = "capstone-macros"
 version = "0.18.0"
 dependencies = [
- "capnp",
- "capnp-import",
- "capnp-rpc",
+ "capstone",
+ "capstone-import",
+ "capstone-rpc",
  "convert_case",
  "proc-macro2",
  "quote",
@@ -270,68 +325,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "capnp-rpc"
+name = "capstone-rpc"
 version = "0.18.0"
 dependencies = [
- "capnp",
- "capnp-futures",
+ "capstone",
+ "capstone-futures",
  "futures",
  "tokio",
-]
-
-[[package]]
-name = "capnp-rpc-test"
-version = "0.0.0"
-dependencies = [
- "async-byte-channel",
- "capnp",
- "capnp-import",
- "capnp-rpc",
- "futures",
- "tokio",
-]
-
-[[package]]
-name = "capnpc"
-version = "0.18.0"
-dependencies = [
- "capnp",
-]
-
-[[package]]
-name = "capnpc-test"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "capnp",
- "capnp-import",
- "capnpc",
- "external-crate",
- "tempfile",
-]
-
-[[package]]
-name = "capnpc-test-edition-2018"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "capnp",
- "capnp-import",
- "capnpc",
- "external-crate",
- "tempfile",
-]
-
-[[package]]
-name = "capnpc-test-edition-2021"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "capnp",
- "capnp-import",
- "capnpc",
- "external-crate",
- "tempfile",
 ]
 
 [[package]]
@@ -529,9 +529,9 @@ name = "external-crate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "capnp",
- "capnp-import",
- "capnpc",
+ "capstone",
+ "capstone-gen",
+ "capstone-import",
  "tempfile",
 ]
 
@@ -545,8 +545,8 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 name = "fill_random_values"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
+ "capstone",
+ "capstone-import",
  "rand",
 ]
 
@@ -735,9 +735,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 name = "hello-world"
 version = "0.0.0"
 dependencies = [
- "capnp",
- "capnp-import",
- "capnp-rpc",
+ "capstone",
+ "capstone-import",
+ "capstone-rpc",
  "futures",
  "tokio",
  "tokio-util",
@@ -1171,9 +1171,9 @@ dependencies = [
 name = "pubsub"
 version = "0.1.0"
 dependencies = [
- "capnp",
- "capnp-import",
- "capnp-rpc",
+ "capstone",
+ "capstone-import",
+ "capstone-rpc",
  "futures",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,21 +33,30 @@ version = "0.18.0"
 edition = "2021"
 rust-version = "1.75.0"
 license = "MIT"
-repository = "https://github.com/fundament-software/capnproto-rust"
-documentation = "https://docs.rs/capnp/"
+repository = "https://github.com/fundament-software/capstone-rs"
+documentation = "https://docs.rs/capstone/"
 readme = "README.md"
 
 [workspace.dependencies]
-tokio = { version = "1.0.0", features = ["net", "rt", "rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1.0.0", features = [
+    "net",
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "sync",
+] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
-capnp = { version = "0.18.0", path = "./capnp" }
-capnpc = { version = "0.18.0", path = "./capnpc" }
-capnp-rpc = { version = "0.18.0", path = "./capnp-rpc" }
-capnp-import = { version = "0.18.0", path = "./capnp-import" }
-capnp-macros = { version = "0.18.0", path = "./capnp-macros" }
-capnp-futures = { version = "0.18.0", path = "./capnp-futures" }
+capstone = { version = "0.18.0", path = "./capnp" }
+capstone-gen = { version = "0.18.0", path = "./capnpc" }
+capstone-rpc = { version = "0.18.0", path = "./capnp-rpc" }
+capstone-import = { version = "0.18.0", path = "./capnp-import" }
+capstone-macros = { version = "0.18.0", path = "./capnp-macros" }
+capstone-futures = { version = "0.18.0", path = "./capnp-futures" }
 async-byte-channel = { path = "./async-byte-channel" }
-futures = { version = "0.3.0", default-features = false, features = ["std", "async-await"] }
+futures = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "async-await",
+] }
 syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -16,5 +16,5 @@ name = "run_all_benchmarks"
 path = "run_all.rs"
 
 [dependencies]
-capnp.workspace = true
-capnp-import.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true

--- a/capnp-futures/Cargo.toml
+++ b/capnp-futures/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
-name = "capnp-futures"
+name = "capstone-futures"
 version.workspace = true
 authors = ["David Renshaw <drenshaw@gmail.com>"]
 license.workspace = true
 description = "async serialization for Cap'n Proto messages"
 repository.workspace = true
-documentation = "https://docs.rs/capnp-futures/"
+documentation = "https://docs.rs/capstone-futures/"
 edition.workspace = true
 readme = "README.md"
 
 keywords = ["async"]
 
+[lib]
+name = "capnp_futures"
+
 [dependencies]
-capnp.workspace = true
+capstone.workspace = true
 quickcheck = { version = "1", optional = true }
 futures.workspace = true
 
 [dev-dependencies]
-capnp = { workspace = true, features = ["quickcheck"] }
+capstone = { workspace = true, features = ["quickcheck"] }
 futures = { workspace = true, features = ["executor"] }
 quickcheck = "1"

--- a/capnp-futures/test/Cargo.toml
+++ b/capnp-futures/test/Cargo.toml
@@ -11,8 +11,8 @@ name = "capnp_futures_test"
 path = "test.rs"
 
 [dependencies]
-capnp-futures.workspace = true
-capnp.workspace = true
-capnp-import.workspace = true
+capstone-futures.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true
 futures.workspace = true
 async-byte-channel.workspace = true

--- a/capnp-import/Cargo.toml
+++ b/capnp-import/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "capnp-import"
+name = "capstone-import"
 version.workspace = true
 authors = ["Erik McClure <erikm@fundament.software>"]
 description = """
-Fetches official Cap-n-Proto compiler (capnp) releases and automatically compiles all capnp files in a set of folders, then combines them in a single capnp_include.rs file.
+Compiles the Fundament capstone fork of capnproto into a usable executable.
 """
 categories = ["compilers", "development-tools::build-utils", "parsing"]
 
@@ -12,17 +12,18 @@ documentation.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true
-homepage = "https://github.com/fundament-software/capnp-import"
+homepage = "https://github.com/fundament-software/capstone-import"
 license.workspace = true
 debug = true
 
 [lib]
+name = "capnp_import"
 proc-macro = true
 
 [dependencies]
 anyhow.workspace = true
-capnpc.workspace = true
-capnp.workspace = true
+capstone-gen.workspace = true
+capstone.workspace = true
 convert_case = "0.6"
 proc-macro2.workspace = true
 quote.workspace = true

--- a/capnp-macros/Cargo.toml
+++ b/capnp-macros/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "capnp-macros"
+name = "capstone-macros"
 version.workspace = true
 edition.workspace = true
 
 [lib]
+name = "capnp_macros"
 proc-macro = true
 
 [dependencies]
-capnp.workspace = true
-capnp-rpc.workspace = true
+capstone.workspace = true
+capstone-rpc.workspace = true
 convert_case = "0.6"
 syn.workspace = true
 proc-macro2.workspace = true
@@ -16,5 +17,5 @@ quote.workspace = true
 
 [dev-dependencies]
 # For testing
-capnp-import.workspace = true
+capstone-import.workspace = true
 tokio.workspace = true

--- a/capnp-rpc/Cargo.toml
+++ b/capnp-rpc/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
 
-name = "capnp-rpc"
+name = "capstone-rpc"
 version.workspace = true
 authors = ["David Renshaw <dwrenshaw@sandstorm.io>"]
 license.workspace = true
 description = "implementation of the Cap'n Proto remote procedure call protocol"
 repository.workspace = true
-documentation = "https://docs.rs/capnp-rpc/"
+documentation = "https://docs.rs/capstone-rpc/"
 categories = ["network-programming"]
 autoexamples = false
 edition.workspace = true
 
 readme = "README.md"
 
+[lib]
+name = "capnp_rpc"
+
 [dependencies.futures]
 workspace = true
 
 [dependencies]
-capnp-futures.workspace = true
-capnp.workspace = true
+capstone-futures.workspace = true
+capstone.workspace = true
 tokio.workspace = true

--- a/capnp-rpc/examples/calculator/Cargo.toml
+++ b/capnp-rpc/examples/calculator/Cargo.toml
@@ -11,9 +11,9 @@ name = "calculator"
 path = "main.rs"
 
 [dependencies]
-capnp.workspace = true
-capnp-import.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true
 futures.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-capnp-rpc.workspace = true
+capstone-rpc.workspace = true

--- a/capnp-rpc/examples/calculator/client.rs
+++ b/capnp-rpc/examples/calculator/client.rs
@@ -20,8 +20,7 @@
 // THE SOFTWARE.
 
 use crate::calculator_capnp::calculator;
-use capnp::capability::Promise;
-use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
 use futures::AsyncReadExt;
 

--- a/capnp-rpc/examples/hello-world/Cargo.toml
+++ b/capnp-rpc/examples/hello-world/Cargo.toml
@@ -10,9 +10,9 @@ name = "hello-world"
 path = "main.rs"
 
 [dependencies]
-capnp.workspace = true
-capnp-import.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true
 futures.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-capnp-rpc.workspace = true
+capstone-rpc.workspace = true

--- a/capnp-rpc/examples/hello-world/server.rs
+++ b/capnp-rpc/examples/hello-world/server.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
 use crate::hello_world_capnp::hello_world;
 

--- a/capnp-rpc/examples/pubsub/Cargo.toml
+++ b/capnp-rpc/examples/pubsub/Cargo.toml
@@ -9,9 +9,9 @@ name = "pubsub"
 path = "main.rs"
 
 [dependencies]
-capnp.workspace = true
-capnp-import.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true
 futures.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-capnp-rpc.workspace = true
+capstone-rpc.workspace = true

--- a/capnp-rpc/examples/pubsub/client.rs
+++ b/capnp-rpc/examples/pubsub/client.rs
@@ -20,9 +20,8 @@
 // THE SOFTWARE.
 
 use crate::pubsub_capnp::{publisher, subscriber};
-use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
-use capnp::capability::Promise;
 use futures::AsyncReadExt;
 
 struct SubscriberImpl;

--- a/capnp-rpc/examples/pubsub/server.rs
+++ b/capnp-rpc/examples/pubsub/server.rs
@@ -24,9 +24,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::pubsub_capnp::{publisher, subscriber, subscription};
-use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
-
-use capnp::capability::Promise;
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 
 use futures::{AsyncReadExt, FutureExt, StreamExt};
 

--- a/capnp-rpc/test/Cargo.toml
+++ b/capnp-rpc/test/Cargo.toml
@@ -11,11 +11,11 @@ name = "capnp_rpc_test"
 path = "test.rs"
 
 [dependencies]
-capnp-rpc.workspace = true
-capnp.workspace = true
+capstone-rpc.workspace = true
+capstone.workspace = true
 futures.workspace = true
 async-byte-channel.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-capnp-import.workspace = true
+capstone-import.workspace = true

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "capnp"
+name = "capstone"
 version.workspace = true
 authors = ["David Renshaw <dwrenshaw@gmail.com>"]
 license.workspace = true
@@ -12,6 +12,9 @@ rust-version.workspace = true
 readme = "README.md"
 
 keywords = ["encoding", "protocol", "serialization"]
+
+[lib]
+name = "capnp"
 
 [dependencies]
 quickcheck = { version = "1", optional = true }
@@ -42,5 +45,5 @@ std = ["embedded-io?/std"]
 sync_reader = []
 
 [lints.clippy]
-type_complexity = "allow"  # this should be removed in future
-missing_safety_doc = "allow"  # this should be removed in future
+type_complexity = "allow"    # this should be removed in future
+missing_safety_doc = "allow" # this should be removed in future

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
-name = "capnpc"
+name = "capstone-gen"
 version.workspace = true
 authors = ["David Renshaw <dwrenshaw@gmail.com>"]
 license.workspace = true
 description = "Cap'n Proto code generation"
 repository.workspace = true
-documentation = "https://docs.rs/capnpc/"
+documentation = "https://docs.rs/capstone-gen/"
 edition.workspace = true
 readme = "README.md"
 
 keywords = ["encoding", "protocol", "serialization"]
+
+[lib]
+name = "capnpc"
 
 [[bin]]
 
@@ -22,5 +25,5 @@ name = "capnpc-rust-bootstrap"
 path = "src/capnpc-rust-bootstrap.rs"
 
 
-[dependencies.capnp]
+[dependencies.capstone]
 workspace = true

--- a/capnpc/test-edition-2015/Cargo.toml
+++ b/capnpc/test-edition-2015/Cargo.toml
@@ -11,12 +11,12 @@ name = "capnpc_test_edition_2015"
 path = "test.rs"
 
 [build-dependencies]
-capnpc.workspace = true
-capnp-import.workspace = true
+capstone-gen.workspace = true
+capstone-import.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true
 
 [dependencies]
-capnp.workspace = true
-capnpc.workspace = true
+capstone.workspace = true
+capstone-gen.workspace = true
 external-crate = { path = "../test/external-crate" }

--- a/capnpc/test-edition-2018/Cargo.toml
+++ b/capnpc/test-edition-2018/Cargo.toml
@@ -11,12 +11,12 @@ name = "capnpc_test_edition_2018"
 path = "test.rs"
 
 [build-dependencies]
-capnpc.workspace = true
-capnp-import.workspace = true
+capstone-gen.workspace = true
+capstone-import.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true
 
 [dependencies]
-capnp.workspace = true
-capnpc.workspace = true
+capstone.workspace = true
+capstone-gen.workspace = true
 external-crate = { path = "../test/external-crate" }

--- a/capnpc/test-edition-2021/Cargo.toml
+++ b/capnpc/test-edition-2021/Cargo.toml
@@ -11,12 +11,12 @@ name = "capnpc_test_edition_2021"
 path = "test.rs"
 
 [build-dependencies]
-capnpc.workspace = true
-capnp-import.workspace = true
+capstone-gen.workspace = true
+capstone-import.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true
 
 [dependencies]
-capnp.workspace = true
-capnpc.workspace = true
+capstone.workspace = true
+capstone-gen.workspace = true
 external-crate = { path = "../test/external-crate" }

--- a/capnpc/test/Cargo.toml
+++ b/capnpc/test/Cargo.toml
@@ -12,12 +12,12 @@ name = "capnpc_test"
 path = "test.rs"
 
 [build-dependencies]
-capnpc.workspace = true
-capnp-import.workspace = true
+capstone-gen.workspace = true
+capstone-import.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true
 
 [dependencies]
-capnp.workspace = true
-capnpc.workspace = true
+capstone.workspace = true
+capstone-gen.workspace = true
 external-crate = { path = "./external-crate" }

--- a/capnpc/test/external-crate/Cargo.toml
+++ b/capnpc/test/external-crate/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-capnp.workspace = true
+capstone.workspace = true
 
 [build-dependencies]
-capnp-import.workspace = true
-capnpc.workspace = true
+capstone-import.workspace = true
+capstone-gen.workspace = true
 tempfile.workspace = true
 anyhow.workspace = true

--- a/example/addressbook/Cargo.toml
+++ b/example/addressbook/Cargo.toml
@@ -11,5 +11,5 @@ name = "addressbook"
 path = "addressbook.rs"
 
 [dependencies]
-capnp-import.workspace = true
-capnp.workspace = true
+capstone-import.workspace = true
+capstone.workspace = true

--- a/example/addressbook_send/Cargo.toml
+++ b/example/addressbook_send/Cargo.toml
@@ -11,5 +11,5 @@ name = "addressbook_send"
 path = "addressbook_send.rs"
 
 [dependencies]
-capnp.workspace = true
-capnp-import.workspace = true
+capstone.workspace = true
+capstone-import.workspace = true

--- a/example/fill_random_values/Cargo.toml
+++ b/example/fill_random_values/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["encoding", "protocol", "serialization"]
 
 [dependencies]
 rand = "0.8.5"
-capnp-import.workspace = true
-capnp.workspace = true
+capstone-import.workspace = true
+capstone.workspace = true
 
 [[bin]]
 name = "fill_addressbook"

--- a/example/wasm-hello-world/Cargo.toml
+++ b/example/wasm-hello-world/Cargo.toml
@@ -10,8 +10,8 @@ members = ["."]
 [dependencies]
 wasmer = "4.0.0"
 
-[dependencies.capnp]
-path = "../../capnp"
+[dependencies.capstone]
+path = "../../capstone"
 
-[dependencies.capnp-import]
-path = "../../capnp-import"
+[dependencies.capstone-import]
+path = "../../capstone-import"

--- a/example/wasm-hello-world/wasm-app/Cargo.toml
+++ b/example/wasm-hello-world/wasm-app/Cargo.toml
@@ -10,10 +10,10 @@ members = ["."]
 [lib]
 crate-type = ["cdylib"]
 
-[dependencies.capnp]
-path = "../../../capnp"
+[dependencies.capstone]
+path = "../../../capstone"
 default-features = false
 features = ["unaligned"]
 
-[dependencies.capnp-import]
-path = "../../../capnp-import"
+[dependencies.capstone-import]
+path = "../../../capstone-import"


### PR DESCRIPTION
Change crate names (but not lib name) to capstone, so the namespace remains `capnp` for the code, but the actual crate import used in cargo.toml is `capstone`.