### PR TITLE
Add very basic DynamicSchema

### DIFF
--- a/capnp-futures/src/serialize.rs
+++ b/capnp-futures/src/serialize.rs
@@ -274,7 +274,7 @@ pub mod test {
 
     #[tokio::test]
     async fn test_read_segment_table() {
-        let mut exec = tokio::task::LocalSet::new();
+        let exec = tokio::task::LocalSet::new();
         let mut buf = vec![];
 
         buf.extend(
@@ -385,7 +385,7 @@ pub mod test {
 
     #[tokio::test]
     async fn test_read_invalid_segment_table() {
-        let mut exec = tokio::task::LocalSet::new();
+        let exec = tokio::task::LocalSet::new();
         let mut buf = vec![];
 
         buf.extend([0, 2, 0, 0]); // 513 segments
@@ -433,7 +433,7 @@ pub mod test {
     }
 
     fn construct_segment_table(segments: &[&[u8]]) -> Vec<u8> {
-        let mut exec = tokio::task::LocalSet::new();
+        let exec = tokio::task::LocalSet::new();
         let mut buf = vec![];
         tokio::runtime::Runtime::new()
             .unwrap()

--- a/capnp-futures/test/test.rs
+++ b/capnp-futures/test/test.rs
@@ -26,7 +26,6 @@ mod tests {
     use crate::addressbook_capnp::{address_book, person};
     use capnp::message;
     use capnp_futures::serialize;
-    use futures_util::TryFutureExt;
 
     fn populate_address_book(address_book: address_book::Builder) {
         let mut people = address_book.init_people(2);
@@ -131,7 +130,7 @@ mod tests {
             read_address_book(address_book.reborrow_as_reader());
         }
 
-        let mut pool = tokio::task::LocalSet::new();
+        let pool = tokio::task::LocalSet::new();
         let (stream0, stream1) = async_byte_channel::channel();
         let f0 = serialize::write_message(stream0, message)
             .map_err(|e| panic!("write error {:?}", e))

--- a/capnp-macros/tests/decorator_tests2.rs
+++ b/capnp-macros/tests/decorator_tests2.rs
@@ -1,6 +1,6 @@
 capnp_import::capnp_import!("tests/test_schema.capnp");
 
-use capnp_macros::{capnp_build, capnproto_rpc};
+use capnp_macros::capnproto_rpc;
 use test_schema_capnp::generic_interface;
 
 #[derive(Default)]

--- a/capnp-rpc/test/reconnect_test.rs
+++ b/capnp-rpc/test/reconnect_test.rs
@@ -201,7 +201,7 @@ where
             // pool.run_until_stalled();
 
             for _ in 0..31 {
-                tokio::task::block_in_place(|| {
+                let _ = tokio::task::block_in_place(|| {
                     tokio::runtime::Handle::current().block_on(PollOnce(pool))
                 });
             }
@@ -248,7 +248,7 @@ where
         // pool.run_until_stalled();
 
         for _ in 0..31 {
-            tokio::task::block_in_place(|| {
+            let _ = tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current().block_on(PollOnce(pool))
             });
         }

--- a/capnp/src/any_pointer.rs
+++ b/capnp/src/any_pointer.rs
@@ -165,6 +165,26 @@ impl<'a> Builder<'a> {
         FromPointerBuilder::init_pointer(self.builder, size)
     }
 
+    pub fn init_dynamic(
+        self,
+        schema: crate::schema::StructSchema,
+    ) -> Result<crate::dynamic_struct::Builder<'a>> {
+        if let crate::schema_capnp::node::Which::Struct(s) = schema.proto.which()? {
+            Ok(crate::dynamic_struct::Builder::new(
+                self.builder
+                    .init_struct(crate::private::layout::StructSize {
+                        data: s.get_data_word_count(),
+                        pointers: s.get_pointer_count(),
+                    }),
+                schema,
+            ))
+        } else {
+            Err(crate::Error::from_kind(
+                crate::ErrorKind::InitIsOnlyValidForStructAndAnyPointerFields,
+            ))
+        }
+    }
+
     pub fn set_as<From: SetPointerBuilder>(&mut self, value: From) -> Result<()> {
         SetPointerBuilder::set_pointer_builder(self.builder.reborrow(), value, false)
     }

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -25,11 +25,16 @@ pub struct DynamicSchema {
 //const PARENT_MODULE_ANNOTATION_ID: u64 = 0xabee386cd1450364;
 //const OPTION_ANNOTATION_ID: u64 = 0xabfef22c4ee1964e;
 
+#[no_mangle]
+#[inline(never)]
 fn dynamic_field_marker(_: u16) -> crate::introspect::Type {
-    panic!("Should never be called!");
+    panic!("dynamic_field_marker should never be called!");
 }
+
+#[no_mangle]
+#[inline(never)]
 fn dynamic_annotation_marker(_: Option<u16>, _: u32) -> crate::introspect::Type {
-    panic!("Should never be called!");
+    panic!("dynamic_annotation_marker should never be called!");
 }
 
 #[cfg(all(feature = "std", feature = "alloc"))]
@@ -418,6 +423,7 @@ impl Field {
     }
 
     pub fn get_type(&self) -> introspect::Type {
+        #[allow(clippy::fn_address_comparisons)]
         if self.parent.raw.field_types == dynamic_field_marker {
             let mut found: Option<crate::schema_capnp::type_::Reader> = None;
             for (index, field) in self.parent.get_fields().unwrap().iter().enumerate() {
@@ -736,6 +742,7 @@ impl AnnotationList {
 
     pub fn get(self, index: u32) -> Annotation {
         let proto = self.annotations.get(index);
+        #[allow(clippy::fn_address_comparisons)]
         let ty = if self.get_annotation_type != dynamic_annotation_marker {
             (self.get_annotation_type)(self.child_index, index)
         } else {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -39,8 +39,8 @@ fn dynamic_annotation_marker(_: Option<u16>, _: u32) -> crate::introspect::Type 
 
 #[cfg(all(feature = "std", feature = "alloc"))]
 impl DynamicSchema {
-    fn get_indexes<'a>(
-        st: crate::schema_capnp::node::struct_::Reader<'a>,
+    fn get_indexes(
+        st: crate::schema_capnp::node::struct_::Reader,
     ) -> (&'static mut [u16], &'static mut [u16]) {
         let mut union_member_indexes = vec![];
         let mut nonunion_member_indexes = vec![];
@@ -90,12 +90,12 @@ impl DynamicSchema {
         Ok(Box::leak(boxed))
     }
 
-    fn process_node<'a>(
+    fn process_node(
         nodes: &mut HashMap<u64, TypeVariant>,
         id: u64,
         root: &mut u64,
         scopes: &mut HashMap<(u64, String), u64>,
-        node_map: &HashMap<u64, crate::schema_capnp::node::Reader<'a>>,
+        node_map: &HashMap<u64, crate::schema_capnp::node::Reader>,
     ) -> Result<()> {
         let node = &node_map[&id];
 
@@ -113,7 +113,7 @@ impl DynamicSchema {
                 let raw = Box::leak(Box::new(introspect::RawStructSchema {
                     encoded_node: leak,
                     nonunion_members: nonunion_member_indexes,
-                    members_by_discriminant: members_by_discriminant,
+                    members_by_discriminant,
                 }));
 
                 let schema = crate::introspect::RawBrandedStructSchema {
@@ -267,7 +267,7 @@ impl std::ops::Drop for DynamicSchema {
         // and start re-capturing the raw pointers into boxes, like trying to herd
         // a bunch of extremely unsafe squirrels that got loose.
 
-        for (_, v) in &mut self.nodes {
+        for v in self.nodes.values_mut() {
             match v {
                 TypeVariant::Struct(s) => {
                     let _ = unsafe {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -11,7 +11,7 @@ use crate::Result;
 #[cfg(feature = "std")]
 use std::collections::hash_map::HashMap;
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "alloc"))]
 // Builds introspection information at runtime to allow building a StructSchema
 pub struct DynamicSchema {
     msg: crate::message::Reader<crate::serialize::OwnedSegments>,
@@ -32,7 +32,7 @@ fn dynamic_annotation_marker(_: Option<u16>, _: u32) -> crate::introspect::Type 
     panic!("Should never be called!");
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "alloc"))]
 impl DynamicSchema {
     fn get_indexes<'a>(
         st: crate::schema_capnp::node::struct_::Reader<'a>,
@@ -255,7 +255,7 @@ impl DynamicSchema {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "alloc"))]
 impl std::ops::Drop for DynamicSchema {
     fn drop(&mut self) {
         // To clean up our mess of memory we have to iterate through all our types

--- a/capnpc/src/codegen_types.rs
+++ b/capnpc/src/codegen_types.rs
@@ -356,8 +356,6 @@ impl<'a> RustTypeInfo for type_::Reader<'a> {
     }
 }
 
-///
-///
 pub fn do_branding(
     ctx: &GeneratorContext,
     node_id: u64,


### PR DESCRIPTION
This allows loading a schema at runtime and extracting parts of it out. Does not do annotations or groups properly, and can' get the field type correct on structs (although this is only needed for certain operations).