### PR TITLE
Allow getting capability schemas dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,12 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,11 +227,11 @@ dependencies = [
 name = "capnpc-test"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "capstone",
  "capstone-gen",
  "capstone-import",
  "external-crate",
+ "eyre",
  "tempfile",
 ]
 
@@ -245,11 +239,11 @@ dependencies = [
 name = "capnpc-test-edition-2018"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "capstone",
  "capstone-gen",
  "capstone-import",
  "external-crate",
+ "eyre",
  "tempfile",
 ]
 
@@ -257,11 +251,11 @@ dependencies = [
 name = "capnpc-test-edition-2021"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "capstone",
  "capstone-gen",
  "capstone-import",
  "external-crate",
+ "eyre",
  "tempfile",
 ]
 
@@ -296,11 +290,11 @@ dependencies = [
 name = "capstone-import"
 version = "0.18.0"
 dependencies = [
- "anyhow",
  "capstone",
  "capstone-gen",
  "cmake",
  "convert_case",
+ "eyre",
  "proc-macro2",
  "quote",
  "relative-path",
@@ -521,11 +515,21 @@ dependencies = [
 name = "external-crate"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "capstone",
  "capstone-gen",
  "capstone-import",
+ "eyre",
  "tempfile",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -816,6 +820,12 @@ name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ futures-util = "0.3"
 syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-anyhow = "1.*"
+eyre = "0.6"
 tempfile = "3.*"

--- a/capnp-import/Cargo.toml
+++ b/capnp-import/Cargo.toml
@@ -21,7 +21,7 @@ name = "capnp_import"
 proc-macro = true
 
 [dependencies]
-anyhow.workspace = true
+eyre.workspace = true
 capstone-gen.workspace = true
 capstone.workspace = true
 convert_case = "0.6"
@@ -34,7 +34,7 @@ tempfile.workspace = true
 
 [build-dependencies]
 relative-path = "1.7.2"
-anyhow.workspace = true
+eyre.workspace = true
 cmake = { version = "0.1" }
 which = "4.3.0"
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/capnp-import/build.rs
+++ b/capnp-import/build.rs
@@ -100,7 +100,7 @@ fn commandhandle() -> eyre::Result<tempfile::TempDir> {{
         .open(tempdir.path().join(\"capnp\"))?;
 
     #[cfg(target_os = \"windows\")]
-    let mut handle = std::fs::OpenOptions::new().write(true).create(true).open(tempdir.path().join(\"capnp\"))?;
+    let mut handle = std::fs::OpenOptions::new().write(true).create(true).truncate(true).open(tempdir.path().join(\"capnp\"))?;
 
     #[cfg(not(any(target_os = \"linux\", target_os = \"macos\", target_os = \"windows\")))]
     compile_error!(\"capnp-import does not support your operating system!\");

--- a/capnp-import/src/lib.rs
+++ b/capnp-import/src/lib.rs
@@ -58,8 +58,7 @@ where
         })
         .collect();
 
-    let manifest: [PathBuf; 1] =
-        [PathBuf::from_str(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).unwrap()];
+    let manifest: [PathBuf; 1] = [PathBuf::from_str(&std::env::var("CARGO_MANIFEST_DIR")?)?];
 
     let globs = path_patterns.into_iter().flat_map(|s| {
         let is_absolute = s.as_ref().starts_with('/');

--- a/capnp-import/src/lib.rs
+++ b/capnp-import/src/lib.rs
@@ -48,7 +48,6 @@ where
     cmd.output_path(&output_dir);
 
     let searchpaths: Vec<PathBuf> = std::env::vars()
-        .into_iter()
         .filter_map(|(key, value)| {
             if key.starts_with("DEP_") && key.ends_with("_SCHEMA_DIR") {
                 cmd.import_path(&value);
@@ -65,7 +64,7 @@ where
     let globs = path_patterns
         .into_iter()
         .flat_map(|s| {
-            let is_absolute = s.as_ref().starts_with("/");
+            let is_absolute = s.as_ref().starts_with('/');
             let closure = move |dir| {
                 wax::walk(s.as_ref().strip_prefix('/').unwrap_or(s.as_ref()), dir)
                     .map_err(BuildError::into_owned)
@@ -160,7 +159,7 @@ mod tests {
 
     #[should_panic]
     #[test]
-    fn search_failure_test() -> () {
+    fn search_failure_test() {
         let folder = PathBuf::from_str(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .unwrap()
             .join("tests");

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -101,7 +101,7 @@ macro_rules! pry {
 mod attach;
 mod broken;
 mod local;
-mod queued;
+pub mod queued;
 mod reconnect;
 mod rpc;
 mod sender_queue;

--- a/capnp-rpc/src/lib.rs
+++ b/capnp-rpc/src/lib.rs
@@ -103,7 +103,7 @@ mod broken;
 mod local;
 pub mod queued;
 mod reconnect;
-mod rpc;
+pub mod rpc;
 mod sender_queue;
 mod split;
 mod task_set;

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -385,10 +385,7 @@ fn remote_exception_to_error(exception: exception::Reader) -> Error {
     let reason_str = reason
         .to_str()
         .unwrap_or("<malformed utf-8 in error reason>");
-    Error {
-        extra: format!("remote exception: {reason_str}"),
-        kind,
-    }
+    ::capnp::Error::from_kind_context(kind, format!("remote exception: {reason_str}"))
 }
 
 pub struct ConnectionErrorHandler<VatId>

--- a/capnp-rpc/src/rpc.rs
+++ b/capnp-rpc/src/rpc.rs
@@ -3141,12 +3141,12 @@ where
 
 // ===================================
 
-struct SingleCapPipeline {
+pub struct SingleCapPipeline {
     cap: Box<dyn ClientHook>,
 }
 
 impl SingleCapPipeline {
-    fn new(cap: Box<dyn ClientHook>) -> Self {
+    pub fn new(cap: Box<dyn ClientHook>) -> Self {
         Self { cap }
     }
 }

--- a/capnp/Cargo.toml
+++ b/capnp/Cargo.toml
@@ -27,6 +27,7 @@ quickcheck = "1"
 
 [features]
 alloc = ["embedded-io?/alloc"]
+backtrace = ["alloc"]
 default = ["std", "alloc"]
 
 rpc_try = []

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -362,29 +362,35 @@ impl Client {
     }
 }
 
+#[cfg(feature = "alloc")]
 // This is an untyped dispatch for an untyped server, which forwards calls directly to dispatch_call
 pub struct UntypedDispatch<_T> {
     pub server: _T,
 }
 
+#[cfg(feature = "alloc")]
 impl<_T: Server> ::core::ops::Deref for UntypedDispatch<_T> {
     type Target = _T;
     fn deref(&self) -> &_T {
         &self.server
     }
 }
+
+#[cfg(feature = "alloc")]
 impl<_T: Server> ::core::ops::DerefMut for UntypedDispatch<_T> {
     fn deref_mut(&mut self) -> &mut _T {
         &mut self.server
     }
 }
+
+#[cfg(feature = "alloc")]
 impl<_T: Server> crate::capability::Server for UntypedDispatch<_T> {
     async fn dispatch_call(
         &self,
         interface_id: u64,
         method_id: u16,
-        params: crate::capability::Params<crate::any_pointer::Owned>,
-        results: crate::capability::Results<crate::any_pointer::Owned>,
+        params: crate::capability::Params<any_pointer::Owned>,
+        results: crate::capability::Results<any_pointer::Owned>,
     ) -> Result<(), crate::Error> {
         self.server
             .dispatch_call(interface_id, method_id, params, results)
@@ -392,6 +398,7 @@ impl<_T: Server> crate::capability::Server for UntypedDispatch<_T> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl crate::introspect::Introspect for Client {
     fn introspect() -> crate::introspect::Type {
         crate::introspect::TypeVariant::Capability(crate::introspect::RawCapabilitySchema {
@@ -401,6 +408,7 @@ impl crate::introspect::Introspect for Client {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<_S: Server + 'static> crate::capability::FromServer<_S> for Client {
     type Dispatch = UntypedDispatch<_S>;
     fn from_server(s: _S) -> UntypedDispatch<_S> {
@@ -408,14 +416,15 @@ impl<_S: Server + 'static> crate::capability::FromServer<_S> for Client {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl crate::capability::FromClientHook for Client {
-    fn new(hook: Box<dyn (crate::private::capability::ClientHook)>) -> Self {
-        Self { hook: hook }
+    fn new(hook: Box<dyn (ClientHook)>) -> Self {
+        Self { hook }
     }
-    fn into_client_hook(self) -> Box<dyn (crate::private::capability::ClientHook)> {
+    fn into_client_hook(self) -> Box<dyn (ClientHook)> {
         self.hook
     }
-    fn as_client_hook(&self) -> &dyn (crate::private::capability::ClientHook) {
+    fn as_client_hook(&self) -> &dyn (ClientHook) {
         &*self.hook
     }
 }

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -306,7 +306,7 @@ pub trait FromTypelessPipeline {
 
 /// Trait implemented (via codegen) by all user-defined capability client types.
 #[cfg(feature = "alloc")]
-pub trait FromClientHook {
+pub trait FromClientHook: crate::introspect::Introspect {
     /// Wraps a client hook to create a new client.
     fn new(hook: Box<dyn ClientHook>) -> Self;
 

--- a/capnp/src/capability_list.rs
+++ b/capnp/src/capability_list.rs
@@ -43,7 +43,7 @@ where
     T: FromClientHook,
 {
     fn introspect() -> crate::introspect::Type {
-        crate::introspect::Type::list_of(crate::introspect::TypeVariant::Capability.into())
+        crate::introspect::Type::list_of(T::introspect())
     }
 }
 
@@ -282,7 +282,7 @@ impl<'a, T: FromClientHook> From<Reader<'a, T>> for crate::dynamic_value::Reader
     fn from(t: Reader<'a, T>) -> crate::dynamic_value::Reader<'a> {
         crate::dynamic_value::Reader::List(crate::dynamic_list::Reader::new(
             t.reader,
-            crate::introspect::TypeVariant::Capability.into(),
+            T::introspect(),
         ))
     }
 }
@@ -291,7 +291,7 @@ impl<'a, T: FromClientHook> From<Builder<'a, T>> for crate::dynamic_value::Build
     fn from(t: Builder<'a, T>) -> crate::dynamic_value::Builder<'a> {
         crate::dynamic_value::Builder::List(crate::dynamic_list::Builder::new(
             t.builder,
-            crate::introspect::TypeVariant::Capability.into(),
+            T::introspect(),
         ))
     }
 }

--- a/capnp/src/dynamic_list.rs
+++ b/capnp/src/dynamic_list.rs
@@ -115,9 +115,9 @@ impl<'a> Reader<'a> {
             TypeVariant::AnyPointer => {
                 Ok(crate::any_pointer::Reader::new(self.reader.get_pointer_element(index)).into())
             }
-            TypeVariant::Capability => {
-                Ok(dynamic_value::Reader::Capability(dynamic_value::Capability))
-            }
+            TypeVariant::Capability(cs) => Ok(dynamic_value::Reader::Capability(
+                dynamic_value::Capability::new(cs.into()),
+            )),
         }
     }
 
@@ -253,8 +253,8 @@ impl<'a> Builder<'a> {
                 self.builder.get_pointer_element(index),
             )
             .into()),
-            TypeVariant::Capability => Ok(dynamic_value::Builder::Capability(
-                dynamic_value::Capability,
+            TypeVariant::Capability(cs) => Ok(dynamic_value::Builder::Capability(
+                dynamic_value::Capability::new(cs.into()),
             )),
         }
     }
@@ -340,7 +340,7 @@ impl<'a> Builder<'a> {
             (TypeVariant::AnyPointer, _) => {
                 Err(Error::from_kind(ErrorKind::ListAnyPointerNotSupported))
             }
-            (TypeVariant::Capability, dynamic_value::Reader::Capability(_)) => {
+            (TypeVariant::Capability(_), dynamic_value::Reader::Capability(_)) => {
                 Err(Error::from_kind(ErrorKind::ListCapabilityNotSupported))
             }
             (_, _) => Err(Error::from_kind(ErrorKind::TypeMismatch)),
@@ -364,7 +364,7 @@ impl<'a> Builder<'a> {
             | TypeVariant::Float64
             | TypeVariant::Enum(_)
             | TypeVariant::Struct(_)
-            | TypeVariant::Capability => Err(Error::from_kind(ErrorKind::ExpectedAListOrBlob)),
+            | TypeVariant::Capability(_) => Err(Error::from_kind(ErrorKind::ExpectedAListOrBlob)),
             TypeVariant::Text => Ok(self
                 .builder
                 .get_pointer_element(index)

--- a/capnp/src/dynamic_value.rs
+++ b/capnp/src/dynamic_value.rs
@@ -57,7 +57,9 @@ impl<'a> Reader<'a> {
                     element_type,
                 )))
             }
-            (value::Interface(()), TypeVariant::Capability) => Ok(Capability.into()),
+            (value::Interface(()), TypeVariant::Capability(c)) => {
+                Ok(Reader::Capability(Capability::new(c.into())))
+            }
             (value::AnyPointer(a), TypeVariant::AnyPointer) => Ok(a.into()),
             _ => Err(crate::Error::from_kind(crate::ErrorKind::TypeMismatch)),
         }
@@ -137,6 +139,7 @@ downcast_reader_impl!(crate::data::Reader<'a>, Data, "data");
 downcast_reader_impl!(dynamic_list::Reader<'a>, List, "list");
 downcast_reader_impl!(dynamic_struct::Reader<'a>, Struct, "struct");
 downcast_reader_impl!(crate::any_pointer::Reader<'a>, AnyPointer, "anypointer");
+downcast_reader_impl!(Capability, Capability, "capability");
 
 /// A dynamically-typed value with mutable interior.
 pub enum Builder<'a> {
@@ -258,6 +261,7 @@ downcast_builder_impl!(crate::data::Builder<'a>, Data, "data");
 downcast_builder_impl!(dynamic_list::Builder<'a>, List, "list");
 downcast_builder_impl!(dynamic_struct::Builder<'a>, Struct, "struct");
 downcast_builder_impl!(crate::any_pointer::Builder<'a>, AnyPointer, "anypointer");
+downcast_builder_impl!(Capability, Capability, "capability");
 
 /// A dynamically-typed enum value.
 #[derive(Clone, Copy)]
@@ -302,7 +306,19 @@ impl<'a> From<Enum> for Builder<'a> {
 /// A dynamic capability. Currently, this is just a stub and does not support calling
 /// of methods.
 #[derive(Clone, Copy)]
-pub struct Capability;
+pub struct Capability {
+    schema: crate::schema::CapabilitySchema,
+}
+
+impl Capability {
+    pub fn new(schema: crate::schema::CapabilitySchema) -> Self {
+        Self { schema }
+    }
+
+    pub fn get_schema(&self) -> crate::schema::CapabilitySchema {
+        self.schema
+    }
+}
 
 impl<'a> From<Capability> for Reader<'a> {
     fn from(c: Capability) -> Reader<'a> {

--- a/capnp/src/lib.rs
+++ b/capnp/src/lib.rs
@@ -186,6 +186,7 @@ impl Clone for Error {
     fn clone(&self) -> Self {
         Self {
             kind: self.kind,
+            #[cfg(feature = "alloc")]
             #[cfg(not(feature = "backtrace"))]
             extra: self.extra.clone(),
             #[cfg(feature = "backtrace")]

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2968,7 +2968,11 @@ impl<'a> PointerReader<'a> {
         }
     }
 
-    pub fn get_list_any_size(self, default_value: *const u8) -> Result<ListReader<'a>> {
+    pub fn get_list_any_size(self, default: Option<&'a [crate::Word]>) -> Result<ListReader<'a>> {
+        let default_value: *const u8 = match default {
+            None => core::ptr::null(),
+            Some(d) => d.as_ptr() as *const u8,
+        };
         let reff = if self.pointer.is_null() {
             zero_pointer()
         } else {
@@ -3065,7 +3069,7 @@ impl<'a> PointerReader<'a> {
                 }
             }
             PointerType::List => unsafe {
-                self.get_list_any_size(ptr::null())?
+                self.get_list_any_size(None)?
                     .is_canonical(read_head, self.pointer)
             },
             PointerType::Capability(_) => Ok(false),

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -114,7 +114,7 @@ pub enum PointerType {
     Null,
     Struct,
     List,
-    Capability,
+    Capability(u32),
 }
 
 impl WirePointerKind {
@@ -2875,6 +2875,10 @@ impl<'a> PointerReader<'a> {
         })
     }
 
+    pub fn get_cap_table(&self) -> &CapTableReader {
+        &self.cap_table
+    }
+
     pub fn reborrow(&self) -> PointerReader<'_> {
         PointerReader {
             arena: self.arena,
@@ -2964,7 +2968,7 @@ impl<'a> PointerReader<'a> {
         }
     }
 
-    fn get_list_any_size(self, default_value: *const u8) -> Result<ListReader<'a>> {
+    pub fn get_list_any_size(self, default_value: *const u8) -> Result<ListReader<'a>> {
         let reff = if self.pointer.is_null() {
             zero_pointer()
         } else {
@@ -3032,7 +3036,7 @@ impl<'a> PointerReader<'a> {
                 WirePointerKind::List => Ok(PointerType::List),
                 WirePointerKind::Other => {
                     if unsafe { (*reff).is_capability() } {
-                        Ok(PointerType::Capability)
+                        unsafe { Ok(PointerType::Capability((*reff).cap_index())) }
                     } else {
                         Err(Error::from_kind(ErrorKind::UnknownPointerType))
                     }
@@ -3064,7 +3068,7 @@ impl<'a> PointerReader<'a> {
                 self.get_list_any_size(ptr::null())?
                     .is_canonical(read_head, self.pointer)
             },
-            PointerType::Capability => Ok(false),
+            PointerType::Capability(_) => Ok(false),
         }
     }
 }
@@ -3519,6 +3523,13 @@ impl<'a> StructReader<'a> {
         Ok(result)
     }
 
+    pub fn struct_size(&self) -> StructSize {
+        StructSize {
+            data: (self.data_size / BITS_PER_WORD as u32) as u16,
+            pointers: self.pointer_count,
+        }
+    }
+
     fn get_location(&self) -> *const u8 {
         self.data
     }
@@ -3787,6 +3798,44 @@ impl<'a> StructBuilder<'a> {
 
         Ok(())
     }
+
+    pub fn copy_data_from(&mut self, other: &StructReader) -> Result<()> {
+        use core::cmp::min;
+        // Determine the amount of data the builders have in common.
+        let shared_data_size = min(self.data_size, other.data_size);
+
+        unsafe {
+            if self.data_size > shared_data_size {
+                // Since the target is larger than the source, make sure to zero out the extra bits that the
+                // source doesn't have.
+                if self.data_size == 1 {
+                    self.set_bool_field(0, false);
+                } else {
+                    let unshared = self
+                        .data
+                        .offset((shared_data_size / BITS_PER_BYTE as u32) as isize);
+                    ptr::write_bytes(
+                        unshared,
+                        0,
+                        ((self.data_size - shared_data_size) / BITS_PER_BYTE as u32) as usize,
+                    );
+                }
+            }
+
+            // Copy over the shared part.
+            if shared_data_size == 1 {
+                self.set_bool_field(0, other.get_bool_field(0));
+            } else {
+                ptr::copy_nonoverlapping(
+                    other.data,
+                    self.data,
+                    (shared_data_size / BITS_PER_BYTE as u32) as usize,
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -3836,7 +3885,14 @@ impl<'a> ListReader<'a> {
         self.step
     }
 
-    pub(crate) fn get_element_size(&self) -> ElementSize {
+    pub fn get_element_struct_size(&self) -> StructSize {
+        StructSize {
+            data: (self.struct_data_size / BITS_PER_WORD as u32) as u16,
+            pointers: self.struct_pointer_count,
+        }
+    }
+
+    pub fn get_element_size(&self) -> ElementSize {
         self.element_size
     }
 

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3307,6 +3307,10 @@ impl<'a> PointerBuilder<'a> {
         );
     }
 
+    pub unsafe fn set_capability_directly(&mut self, cap: u32) {
+        (*self.pointer).set_cap(cap);
+    }
+
     pub fn copy_from(&mut self, other: PointerReader, canonicalize: bool) -> Result<()> {
         if other.pointer.is_null() {
             if !self.pointer.is_null() {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -244,6 +244,11 @@ impl DynamicSchema {
         }
         Ok(this)
     }
+
+    pub fn get_type_by_id(&self, id: u64) -> Option<&TypeVariant> {
+        self.nodes.get(&id)
+    }
+
     pub fn get_type_by_scope(&self, scope: Vec<String>) -> Option<&TypeVariant> {
         let mut parent = self.root;
         let mut result = None;
@@ -793,7 +798,7 @@ impl ::core::iter::IntoIterator for AnnotationList {
 /// A capability schema
 #[derive(Clone, Copy)]
 pub struct CapabilitySchema {
-    pub(crate) raw: RawCapabilitySchema,
+    pub(crate) _raw: RawCapabilitySchema,
     pub(crate) proto: node::Reader<'static>,
 }
 
@@ -804,7 +809,7 @@ impl CapabilitySchema {
         })
         .get_as()
         .unwrap();
-        Self { raw, proto }
+        Self { _raw: raw, proto }
     }
 
     pub fn get_proto(self) -> node::Reader<'static> {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -486,17 +486,17 @@ impl Field {
                 crate::schema_capnp::type_::Which::Text(_) => introspect::TypeVariant::Text,
                 crate::schema_capnp::type_::Which::Data(_) => introspect::TypeVariant::Data,
                 crate::schema_capnp::type_::Which::List(_) => {
-                    panic!("aaa");
+                    todo!();
                 }
-                crate::schema_capnp::type_::Which::Enum(_) => {
-                    panic!("aaa");
-                }
+                crate::schema_capnp::type_::Which::Enum(_) => TypeVariant::Enum(RawEnumSchema {
+                    encoded_node: &[],
+                    annotation_types: dynamic_annotation_marker,
+                }),
                 crate::schema_capnp::type_::Which::Struct(_) => {
-                    panic!("aaa");
+                    todo!();
                 }
                 crate::schema_capnp::type_::Which::Interface(_) => {
-                    //TypeVariant::Capability(RawCapabilitySchema { encoded_node: leak }),
-                    panic!("aaa");
+                    TypeVariant::Capability(RawCapabilitySchema { encoded_node: &[] })
                 }
                 crate::schema_capnp::type_::Which::AnyPointer(_) => {
                     introspect::TypeVariant::AnyPointer
@@ -779,7 +779,8 @@ impl AnnotationList {
         let ty = if self.get_annotation_type != dynamic_annotation_marker {
             (self.get_annotation_type)(self.child_index, index)
         } else {
-            panic!("aaa");
+            // We do not support dynamic annotations yet
+            todo!();
         };
 
         Annotation { proto, ty }

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2339,13 +2339,13 @@ fn generate_node(
                     Branch(vec![
                         Line(format!("pub struct Pipeline{bracketed_params} {{")),
                         indent(vec![
-                            Line(fmt!(ctx,"pub _typeless: {capnp}::any_pointer::Pipeline,")),
+                            Line(fmt!(ctx,"_typeless: {capnp}::any_pointer::Pipeline,")),
                             Line(params.phantom_data_type),
                         ]),
                         line("}")
                     ])
                 } else {
-                    Line(fmt!(ctx,"pub struct Pipeline {{ pub _typeless: {capnp}::any_pointer::Pipeline }}"))
+                    Line(fmt!(ctx,"pub struct Pipeline {{ _typeless: {capnp}::any_pointer::Pipeline }}"))
                 }),
                 Line(fmt!(ctx,"impl{bracketed_params} {capnp}::capability::FromTypelessPipeline for Pipeline{bracketed_params} {{")),
                 indent(vec![

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -2339,13 +2339,13 @@ fn generate_node(
                     Branch(vec![
                         Line(format!("pub struct Pipeline{bracketed_params} {{")),
                         indent(vec![
-                            Line(fmt!(ctx,"_typeless: {capnp}::any_pointer::Pipeline,")),
+                            Line(fmt!(ctx,"pub _typeless: {capnp}::any_pointer::Pipeline,")),
                             Line(params.phantom_data_type),
                         ]),
                         line("}")
                     ])
                 } else {
-                    Line(fmt!(ctx,"pub struct Pipeline {{ _typeless: {capnp}::any_pointer::Pipeline }}"))
+                    Line(fmt!(ctx,"pub struct Pipeline {{ pub _typeless: {capnp}::any_pointer::Pipeline }}"))
                 }),
                 Line(fmt!(ctx,"impl{bracketed_params} {capnp}::capability::FromTypelessPipeline for Pipeline{bracketed_params} {{")),
                 indent(vec![

--- a/capnpc/src/lib.rs
+++ b/capnpc/src/lib.rs
@@ -89,10 +89,7 @@ pub(crate) fn convert_io_err(err: std::io::Error) -> capnp::Error {
         | io::ErrorKind::NotConnected => capnp::ErrorKind::Disconnected,
         _ => capnp::ErrorKind::Failed,
     };
-    capnp::Error {
-        extra: format!("{err}"),
-        kind,
-    }
+    capnp::Error::from_kind_context(kind, format!("{err}"))
 }
 
 fn run_command(

--- a/capnpc/test-edition-2015/Cargo.toml
+++ b/capnpc/test-edition-2015/Cargo.toml
@@ -14,7 +14,7 @@ path = "test.rs"
 capstone-gen.workspace = true
 capstone-import.workspace = true
 tempfile.workspace = true
-anyhow.workspace = true
+eyre.workspace = true
 
 [dependencies]
 capstone.workspace = true

--- a/capnpc/test-edition-2018/Cargo.toml
+++ b/capnpc/test-edition-2018/Cargo.toml
@@ -14,7 +14,7 @@ path = "test.rs"
 capstone-gen.workspace = true
 capstone-import.workspace = true
 tempfile.workspace = true
-anyhow.workspace = true
+eyre.workspace = true
 
 [dependencies]
 capstone.workspace = true

--- a/capnpc/test-edition-2021/Cargo.toml
+++ b/capnpc/test-edition-2021/Cargo.toml
@@ -14,7 +14,7 @@ path = "test.rs"
 capstone-gen.workspace = true
 capstone-import.workspace = true
 tempfile.workspace = true
-anyhow.workspace = true
+eyre.workspace = true
 
 [dependencies]
 capstone.workspace = true

--- a/capnpc/test/Cargo.toml
+++ b/capnpc/test/Cargo.toml
@@ -15,7 +15,7 @@ path = "test.rs"
 capstone-gen.workspace = true
 capstone-import.workspace = true
 tempfile.workspace = true
-anyhow.workspace = true
+eyre.workspace = true
 
 [dependencies]
 capstone.workspace = true

--- a/capnpc/test/external-crate/Cargo.toml
+++ b/capnpc/test/external-crate/Cargo.toml
@@ -12,4 +12,4 @@ capstone.workspace = true
 capstone-import.workspace = true
 capstone-gen.workspace = true
 tempfile.workspace = true
-anyhow.workspace = true
+eyre.workspace = true

--- a/example/fill_random_values/src/lib.rs
+++ b/example/fill_random_values/src/lib.rs
@@ -170,7 +170,7 @@ impl<R: Rng> Filler<R> {
             }
 
             TypeVariant::AnyPointer => Ok(()),
-            TypeVariant::Capability => Ok(()),
+            TypeVariant::Capability(_) => Ok(()),
         }
     }
 
@@ -209,7 +209,7 @@ impl<R: Rng> Filler<R> {
                 self.fill_list(recursion_depth + 1, builder.get(index)?.downcast())
             }
             TypeVariant::AnyPointer => Ok(()),
-            TypeVariant::Capability => Ok(()),
+            TypeVariant::Capability(_) => Ok(()),
         }
     }
 


### PR DESCRIPTION
Allows accessing a capability's schema dynamically. Tested in keystone only.

Also includes extremely unsafe "directly set capability integer". This is necessary until the capabilities are refactored properly.