### PR TITLE
capnp-import: Put results into hashed files and include! them

### DIFF
--- a/capnp-import/src/lib.rs
+++ b/capnp-import/src/lib.rs
@@ -31,13 +31,18 @@ pub fn capnp_import(input: TokenStream) -> TokenStream {
     path_patterns.hash(&mut hasher);
 
     let helperfile = process_inner(path_patterns).unwrap();
-    let file_path = format!("{}/{}.rs", env!("OUT_DIR"), hasher.finish());
-    let _ = fs::write(&file_path, helperfile.to_string());
+    if let Ok(out_dir) = std::env::var("OUT_DIR") {
+        let file_path = PathBuf::from_str(&format!("{}/{}.rs", out_dir, hasher.finish())).unwrap();
+        let _ = fs::write(&file_path, helperfile.to_string());
+        let file_out = file_path.to_string_lossy().to_string();
 
-    quote! {
-        include!(#file_path);
+        quote! {
+            include!(#file_out);
+        }
+        .into()
+    } else {
+        helperfile.into()
     }
-    .into()
 }
 
 #[proc_macro]

--- a/capnpc/src/codegen.rs
+++ b/capnpc/src/codegen.rs
@@ -914,7 +914,7 @@ fn zero_fields_of_group(
     node_id: u64,
     clear: &mut bool,
 ) -> ::capnp::Result<FormattedText> {
-    use capnp::schema_capnp::{field, node, type_};
+    use capnp::schema_capnp::{field, node};
     match ctx.node_map[&node_id].which()? {
         node::Struct(st) => {
             let mut result = Vec::new();
@@ -1583,7 +1583,6 @@ fn used_params_of_type(
     ty: schema_capnp::type_::Reader,
     used_params: &mut HashSet<String>,
 ) -> capnp::Result<()> {
-    use capnp::schema_capnp::type_;
     match ty.which()? {
         type_::List(ls) => {
             let et = ls.get_element_type()?;
@@ -2048,7 +2047,7 @@ fn generate_pipeline_getter(
     ctx: &GeneratorContext,
     field: schema_capnp::field::Reader,
 ) -> ::capnp::Result<FormattedText> {
-    use capnp::schema_capnp::{field, type_};
+    use capnp::schema_capnp::field;
 
     let name = get_field_name(field)?;
 
@@ -2348,7 +2347,6 @@ fn get_ty_params_of_type_helper(
     accumulator: &mut HashSet<(u64, u16)>,
     typ: schema_capnp::type_::Reader,
 ) -> ::capnp::Result<()> {
-    use capnp::schema_capnp::type_;
     match typ.which()? {
         type_::Void(())
         | type_::Bool(())


### PR DESCRIPTION
Possibly adresses a rust-analyzer error of exceeding a token limit, but I haven't been able to verify that