### PR TITLE
Extend CompilerCommand and DynamicSchema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bzip2"
@@ -278,6 +278,9 @@ name = "capstone-gen"
 version = "0.18.0"
 dependencies = [
  "capstone",
+ "convert_case",
+ "walkdir",
+ "wax",
 ]
 
 [[package]]
@@ -329,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 dependencies = [
  "jobserver",
  "libc",
@@ -569,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -890,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -926,9 +929,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1088,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1246,9 +1249,12 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1333,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1459,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64",
  "rustls-pki-types",
@@ -1469,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -1501,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.5"
+version = "2.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fadf67e3cf23f8b11a6c8c48a16cb2437381503615acd91094ec7b4686a5a53"
+checksum = "06ff467073ddaff34c3a39e5b454f25dd982484a26fff50254ca793c56a1b714"
 dependencies = [
  "sdd",
 ]
@@ -1525,9 +1531,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f05a494052771fc5bd0619742363b5e24e5ad72ab3111ec2e27925b8edc5f3"
+checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
 
 [[package]]
 name = "security-framework"
@@ -1560,18 +1566,18 @@ checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1580,11 +1586,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1725,14 +1732,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1968,9 +1976,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2102,11 +2110,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2123,6 +2131,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2270,6 +2287,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -2341,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -463,6 +463,7 @@ pub async fn get_resolved_cap<C: FromClientHook>(cap: C) -> C {
     FromClientHook::new(hook)
 }
 
+#[cfg(feature = "alloc")]
 impl core::fmt::Debug for dyn ClientHook {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!(

--- a/capnp/src/capability.rs
+++ b/capnp/src/capability.rs
@@ -462,3 +462,13 @@ pub async fn get_resolved_cap<C: FromClientHook>(cap: C) -> C {
     }
     FromClientHook::new(hook)
 }
+
+impl core::fmt::Debug for dyn ClientHook {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_fmt(format_args!(
+            "Cap index: {} (Brand: {})",
+            self.get_ptr(),
+            self.get_brand(),
+        ))
+    }
+}

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -52,6 +52,21 @@ pub trait ReaderArena {
     //   layout::StructReader, layout::ListReader, etc. could drop their `cap_table` fields.
 }
 
+impl core::fmt::Debug for dyn ReaderArena {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut id = 0;
+        loop {
+            if let Ok((p, len)) = self.get_segment(id) {
+                f.write_fmt(format_args!("Segment {}: {:?} ({} bytes)", id, p, len))?;
+            } else {
+                break;
+            }
+            id = id + 1
+        }
+        f.write_fmt(format_args!("Nesting Limit: {}", self.nesting_limit()))
+    }
+}
+
 pub struct ReaderArenaImpl<S> {
     segments: S,
     read_limiter: ReadLimiter,

--- a/capnp/src/private/arena.rs
+++ b/capnp/src/private/arena.rs
@@ -52,7 +52,7 @@ pub trait ReaderArena {
     //   layout::StructReader, layout::ListReader, etc. could drop their `cap_table` fields.
 }
 
-impl core::fmt::Debug for dyn ReaderArena {
+impl core::fmt::Debug for dyn ReaderArena + '_ {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut id = 0;
         loop {
@@ -327,8 +327,10 @@ where
     A: Allocator,
 {
     fn get_segment(&self, id: u32) -> Result<(*const u8, u32)> {
-        let seg = &self.inner.segments[id as usize];
-        Ok((seg.ptr, seg.allocated))
+        match self.inner.segments.get(id as usize) {
+            Some(seg) => Ok((seg.ptr, seg.allocated)),
+            None => Err(Error::from_kind(ErrorKind::InvalidSegmentId(id))),
+        }
     }
 
     unsafe fn check_offset(

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -3387,7 +3387,7 @@ impl<'a> PointerBuilder<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct StructReader<'a> {
     arena: &'a dyn ReaderArena,
     cap_table: CapTableReader,
@@ -3397,31 +3397,6 @@ pub struct StructReader<'a> {
     data_size: BitCount32,
     pointer_count: WirePointerCount16,
     nesting_limit: i32,
-}
-
-impl<'a> core::fmt::Debug for StructReader<'a> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let s = format!("{:?}", self.arena);
-        f.write_fmt(format_args!(
-            "arena: {}
-        cap_table: {:?}
-        data: {:?}
-        pointers: {:?}
-        segment_id: {}
-        data_size: {}
-        pointer_count: {}
-        nesting_limit: {}
-        ",
-            s,
-            self.cap_table,
-            self.data,
-            self.pointers,
-            self.segment_id,
-            self.data_size,
-            self.pointer_count,
-            self.nesting_limit
-        ))
-    }
 }
 
 impl<'a> StructReader<'a> {

--- a/capnp/src/private/layout.rs
+++ b/capnp/src/private/layout.rs
@@ -2725,7 +2725,7 @@ pub type CapTable = Vec<Option<Box<dyn ClientHook>>>;
 #[cfg(not(feature = "alloc"))]
 pub struct CapTable;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CapTableReader {
     // At one point, we had a `Dummy` variant here, but that ended up
     // making values of this type take 16 bytes of memory. Now we instead
@@ -3397,6 +3397,31 @@ pub struct StructReader<'a> {
     data_size: BitCount32,
     pointer_count: WirePointerCount16,
     nesting_limit: i32,
+}
+
+impl<'a> core::fmt::Debug for StructReader<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let s = format!("{:?}", self.arena);
+        f.write_fmt(format_args!(
+            "arena: {}
+        cap_table: {:?}
+        data: {:?}
+        pointers: {:?}
+        segment_id: {}
+        data_size: {}
+        pointer_count: {}
+        nesting_limit: {}
+        ",
+            s,
+            self.cap_table,
+            self.data,
+            self.pointers,
+            self.segment_id,
+            self.data_size,
+            self.pointer_count,
+            self.nesting_limit
+        ))
+    }
 }
 
 impl<'a> StructReader<'a> {

--- a/capnp/src/schema.rs
+++ b/capnp/src/schema.rs
@@ -29,7 +29,7 @@ pub struct DynamicSchema {
     // so never expose this directly or clone it
     nodes: Arc<HashMap<u64, TypeVariant>>,
     token: DynamicSchemaToken,
-    root: u64,
+    files: HashMap<String, u64>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -277,7 +277,6 @@ impl DynamicSchema {
     pub fn new<S: crate::message::ReaderSegments>(msg: Reader<S>) -> Result<Self> {
         let mut scopes = HashMap::new();
         let mut node_parents = HashMap::new();
-        let mut root = 0;
         let token = DynamicSchemaToken::new();
 
         let mut nodes = HashMap::new();
@@ -306,8 +305,10 @@ impl DynamicSchema {
         }
 
         // Fix up imported files
+        let mut files = HashMap::new();
         for requested_file in request.get_requested_files()? {
             let id = requested_file.get_id();
+            files.insert(requested_file.get_filename()?.to_string()?, id);
 
             for import in requested_file.get_imports()? {
                 let import_id = import.get_id();
@@ -319,15 +320,6 @@ impl DynamicSchema {
         }
 
         for node in request.get_nodes()? {
-            if node_parents[&node.get_id()] == 0 {
-                root = match root {
-                    0 => Ok(node.get_id()),
-                    _ => Err(crate::Error::from_kind(
-                        crate::ErrorKind::MessageIsTooDeeplyNestedOrContainsCycles,
-                    )),
-                }?;
-            }
-
             Self::process_node(&mut nodes, node.get_id(), &mut scopes, &node_map, token)?;
         }
 
@@ -335,7 +327,7 @@ impl DynamicSchema {
             msg: S::reader_into_owned(msg).ok(),
             scopes,
             nodes: Arc::new(nodes),
-            root,
+            files,
             token,
         };
 
@@ -350,25 +342,37 @@ impl DynamicSchema {
         self.nodes.get(&id)
     }
 
-    pub fn get_type_by_scope(&self, scope: Vec<String>) -> Option<&TypeVariant> {
-        let mut parent = self.root;
+    pub fn get_type_by_scope(
+        &self,
+        scope: &[impl AsRef<str>],
+        file: Option<&str>,
+    ) -> Result<&TypeVariant> {
+        let mut parent = if let Some(f) = file {
+            *self.files.get(f).ok_or(crate::Error::failed(format!(
+                "{} is not a file in this DynamicSchema",
+                f
+            )))?
+        } else if self.files.len() > 1 {
+            return Err(crate::Error::failed(
+                "Cannot infer root filename because DynamicSchema set has more than one file"
+                    .into(),
+            ));
+        } else {
+            *self.files.values().next().ok_or(crate::Error::failed(
+                "DynamicSchema does not contain a root file.".into(),
+            ))?
+        };
         let mut result = None;
 
         for name in scope {
-            let key = &(parent, name);
+            let key = &(parent, name.as_ref().to_string());
             result = self.scopes.get(key);
-            if let Some(x) = result {
-                parent = *x;
-            } else {
-                return None;
-            }
+            parent = *result.ok_or(crate::Error::failed(format!("{} was not in scope", key.1)))?;
         }
 
-        if let Some(k) = result {
-            self.nodes.get(k)
-        } else {
-            None
-        }
+        self.nodes
+            .get(result.ok_or(crate::Error::failed("Invalid scope".into()))?)
+            .ok_or(crate::Error::failed("Internal child lookup failure".into()))
     }
 }
 

--- a/capnpc/Cargo.toml
+++ b/capnpc/Cargo.toml
@@ -24,6 +24,8 @@ path = "src/capnpc-rust.rs"
 name = "capnpc-rust-bootstrap"
 path = "src/capnpc-rust-bootstrap.rs"
 
-
-[dependencies.capstone]
-workspace = true
+[dependencies]
+wax = "0.6.0"
+walkdir = "2"
+convert_case = "0.6"
+capstone.workspace = true


### PR DESCRIPTION
Adds debug prints, extends CompilerCommand so it can be manually invoked outside of capnp-import, and allows DynamicSchema to handle multiple files properly.